### PR TITLE
CI: also run on arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,12 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Github now has arm64 runners, let's use them to build & test on arm64.

Note: there is no "ubuntu-latest-arm" [1], so I used the latest arm64 image as of this writing, which
is ubuntu-24.04-arm.

[1] https://github.com/orgs/community/discussions/148648#discussioncomment-11858187