### PR TITLE
Aegis: panic on inexact buffer overlap in Seal/Open

### DIFF
--- a/aegis128l/aegis128l.go
+++ b/aegis128l/aegis128l.go
@@ -60,6 +60,9 @@ func (aead *Aegis128L) Seal(dst, nonce, cleartext, additionalData []byte) []byte
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis128l_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis128L) Open(plaintext, nonce, ciphertext, additionalData []byte)
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis128l_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis128l/aegis128l_test.go
+++ b/aegis128l/aegis128l_test.go
@@ -3,9 +3,95 @@ package aegis128l
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/aegis128x2/aegis128x2.go
+++ b/aegis128x2/aegis128x2.go
@@ -60,6 +60,9 @@ func (aead *Aegis128X2) Seal(dst, nonce, cleartext, additionalData []byte) []byt
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis128x2_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis128X2) Open(plaintext, nonce, ciphertext, additionalData []byte
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis128x2_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis128x2/aegis128x2_test.go
+++ b/aegis128x2/aegis128x2_test.go
@@ -3,9 +3,95 @@ package aegis128x2
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/aegis128x4/aegis128x4.go
+++ b/aegis128x4/aegis128x4.go
@@ -60,6 +60,9 @@ func (aead *Aegis128X4) Seal(dst, nonce, cleartext, additionalData []byte) []byt
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis128x4_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis128X4) Open(plaintext, nonce, ciphertext, additionalData []byte
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis128x4_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis128x4/aegis128x4_test.go
+++ b/aegis128x4/aegis128x4_test.go
@@ -3,9 +3,95 @@ package aegis128x4
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/aegis256/aegis256.go
+++ b/aegis256/aegis256.go
@@ -60,6 +60,9 @@ func (aead *Aegis256) Seal(dst, nonce, cleartext, additionalData []byte) []byte 
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis256_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis256) Open(plaintext, nonce, ciphertext, additionalData []byte) 
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis256_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis256/aegis256_test.go
+++ b/aegis256/aegis256_test.go
@@ -3,9 +3,95 @@ package aegis256
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/aegis256x2/aegis256x2.go
+++ b/aegis256x2/aegis256x2.go
@@ -60,6 +60,9 @@ func (aead *Aegis256X2) Seal(dst, nonce, cleartext, additionalData []byte) []byt
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis256x2_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis256X2) Open(plaintext, nonce, ciphertext, additionalData []byte
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis256x2_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis256x2/aegis256x2_test.go
+++ b/aegis256x2/aegis256x2_test.go
@@ -3,9 +3,95 @@ package aegis256x2
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/aegis256x4/aegis256x4.go
+++ b/aegis256x4/aegis256x4.go
@@ -60,6 +60,9 @@ func (aead *Aegis256X4) Seal(dst, nonce, cleartext, additionalData []byte) []byt
 	} else {
 		buf = make([]byte, outLen)
 	}
+	if common.InexactOverlap(buf, cleartext) {
+		panic("aegis: invalid buffer overlap")
+	}
 	res := C.aegis256x4_encrypt((*C.uchar)(&buf[0]), C.size_t(aead.TagLen), slicePointerOrNull(cleartext),
 		C.size_t(len(cleartext)), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))
 	if res != 0 {
@@ -90,6 +93,9 @@ func (aead *Aegis256X4) Open(plaintext, nonce, ciphertext, additionalData []byte
 		buf = plaintext[len(plaintext) : len(plaintext)+outLen]
 	} else {
 		buf = make([]byte, len(ciphertext)-aead.TagLen)
+	}
+	if common.InexactOverlap(buf, ciphertext) {
+		panic("aegis: invalid buffer overlap")
 	}
 	res := C.aegis256x4_decrypt(slicePointerOrNull(buf), (*C.uchar)(&ciphertext[0]),
 		C.size_t(len(ciphertext)), C.size_t(aead.TagLen), slicePointerOrNull(additionalData), C.size_t(len(additionalData)), (*C.uchar)(&nonce[0]), (*C.uchar)(&aead.Key[0]))

--- a/aegis256x4/aegis256x4_test.go
+++ b/aegis256x4/aegis256x4_test.go
@@ -3,9 +3,95 @@ package aegis256x4
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
 	"github.com/aegis-aead/go-libaegis/common"
 )
+
+func mustPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The code did not panic")
+		}
+	}()
+
+	f()
+}
+
+func TestInexactOverlap(t *testing.T) {
+	if !common.Available {
+		t.Skip("cgo is required to use AEGIS")
+	}
+
+	textLength := 82
+	key := make([]byte, KeySize)
+	rand.Read(key)
+
+	aead, err := New(key, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	rand.Read(nonce)
+
+	t.Run("Seal", func(t *testing.T) {
+		originalCleartext := make([]byte, textLength)
+		rand.Read(originalCleartext)
+
+		buf := make([]byte, textLength*2+aead.Overhead())
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[:0]
+			aead.Seal(dst, nonce, cleartext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			cleartext := buf[:textLength]
+			copy(cleartext, originalCleartext)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Seal(dst, nonce, cleartext, nil) })
+		})
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		cleartext := make([]byte, textLength)
+		rand.Read(cleartext)
+
+		control := aead.Seal(nil, nonce, cleartext, nil)
+		buf := make([]byte, textLength+len(control))
+
+		t.Run("Exact overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[:0]
+			aead.Open(dst, nonce, ciphertext, nil)
+		})
+
+		t.Run("One-byte-shift", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[1:1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+
+		t.Run("One-byte-overlap", func(t *testing.T) {
+			ciphertext := buf[:len(control)]
+			copy(ciphertext, control)
+			dst := buf[textLength-1 : textLength-1]
+			mustPanic(t, func() { aead.Open(dst, nonce, ciphertext, nil) })
+		})
+	})
+}
 
 func Example() {
 	if !common.Available {

--- a/common/overlap.go
+++ b/common/overlap.go
@@ -1,0 +1,17 @@
+package common
+
+import "unsafe"
+
+func InexactOverlap(x, y []byte) bool {
+	if len(x) == 0 || len(y) == 0 {
+		return false
+	}
+	if &x[0] == &y[0] {
+		return false
+	}
+	x0 := uintptr(unsafe.Pointer(&x[0]))
+	x1 := x0 + uintptr(len(x))
+	y0 := uintptr(unsafe.Pointer(&y[0]))
+	y1 := y0 + uintptr(len(y))
+	return x0 < y1 && y0 < x1
+}


### PR DESCRIPTION
## Current behavior
If someone were to mistakenly provide a destination buffer to Open that overlaps ciphertext, but the overlap is not exact, AEGIS will not be able to decrypt and authenticate the message.
<img width="2249" height="983" alt="image" src="https://github.com/user-attachments/assets/ac3788dd-8b77-4503-8729-a6c6a446483c" />

What's worse, if someone were to mistakenly provide a destination buffer to Seal that overlaps cleartext, where overlap is not exact, AEGIS will encrypt the cleartext and will produce an authentication tag. Decryption and authentication of such ciphertext will succeed, but the returned data will be malformed.
<img width="2249" height="1130" alt="image" src="https://github.com/user-attachments/assets/cd125af1-661d-4b16-96a6-bb85d7e103df" />

## Proposed change
To eliminate this issue I propose to check for overlap early and panic if such overlap is found with
``` golang
func InexactOverlap(x, y []byte) bool {
	if len(x) == 0 || len(y) == 0 {
		return false
	}
	if &x[0] == &y[0] {
		return false
	}
	x0 := uintptr(unsafe.Pointer(&x[0]))
	x1 := x0 + uintptr(len(x))
	y0 := uintptr(unsafe.Pointer(&y[0]))
	y1 := y0 + uintptr(len(y))
	return x0 < y1 && y0 < x1
}
```
This also aligns with the requirements of [cipher.AEAD](https://cs.opensource.google/go/go/+/go1.25.0:src/crypto/cipher/cipher.go;l=81) interface.

> Otherwise, the remaining capacity of dst must not overlap plaintext/ciphertext.
